### PR TITLE
Fixes #6 #time 15m

### DIFF
--- a/gateway.js
+++ b/gateway.js
@@ -22,7 +22,8 @@ module.exports = function gateway(docroot, options) {
   var exts = Object.keys(options).filter(function(o) { return o[0] == '.'})
 
   function isMalicious(path) {
-    return path.indexOf(docroot) !== 0
+		// docroot array then index 0 is a windows filesystem fix please do not remove!
+    return path.indexOf([docroot][0]) !== 0
       || ~path.indexOf('\0')
       || ~path.indexOf('..')
   }

--- a/gateway.js
+++ b/gateway.js
@@ -12,6 +12,10 @@ module.exports = function gateway(docroot, options) {
 
   // docroot is required
   if (!docroot) throw new Error('gateway() requires docroot')
+	if(/^win/i.test(process.platform)){
+		// fixes windows paths
+		docroot = docroot.replace(/\//gi,"\\");
+	}
 
   // default mapping
   if (!options) options = {
@@ -23,7 +27,7 @@ module.exports = function gateway(docroot, options) {
 
   function isMalicious(path) {
 		// docroot array then index 0 is a windows filesystem fix please do not remove!
-    return path.indexOf([docroot][0]) !== 0
+    return path.indexOf(docroot) !== 0
       || ~path.indexOf('\0')
       || ~path.indexOf('..')
   }


### PR DESCRIPTION
- windows was failing the isMalicious check because node automatically delimits strings when pushed into arrays.
- fixed by pushing docroot into an array, triggering node automatic delimitation
