### PR TITLE
Added missing REMOTE_ADDR and SERVER_SOFTWARE values in php-cgi env.

### DIFF
--- a/gateway.js
+++ b/gateway.js
@@ -86,7 +86,9 @@ module.exports = function gateway(docroot, options) {
         SCRIPT_FILENAME: file,
         PATH_TRANSLATED: file,
         REQUEST_METHOD: req.method,
-        QUERY_STRING: url.query || ''
+        QUERY_STRING: url.query || '',
+        REMOTE_ADDR: req.connection.remoteAddress,
+        SERVER_SOFTWARE: options['.php']
       }
 
       // expose request headers


### PR DESCRIPTION
Had an trying to execute the update.php page of drupal.
Turns out it was looking for `REMOTE_ADDR` and `SERVER_SOFTWARE` in `$_SERVER`.

So i just added them.
