### PR TITLE
Multiple gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ var app = http.createServer(gateway(__dirname, {
 ## Installing php-cgi
 
 The `php-cgi` binary can be installed via Homebrew by tapping the
-[homebrew-php](https://github.com/josegonzalez/homebrew-php) repository:
+[homebrew-php](https://github.com/Homebrew/homebrew-php) repository:
 
     brew tap homebrew/dupes
-    brew tap josegonzalez/homebrew-php
-    brew install php54
+    brew tap homebrew/versions
+    brew tap homebrew/homebrew-php
+    brew install php56
 
 ## Directories
 

--- a/gateway.js
+++ b/gateway.js
@@ -47,7 +47,7 @@ module.exports = function gateway(docroot, options) {
 
       // file does not exist
       if (!file) {
-        if (options[extname(path)]) {
+        if (options[extname(path)] && options.no404 !== true) {
           // ... but a handler is registered for the extension
           res.writeHead(404)
           return res.end()


### PR DESCRIPTION
Add a `no404` option, to allow gateway to be configured not to serve a 404 if a file with a registered handler is not found.  This is useful for configuring multiple gateways with the same handler on multiple base directories.

Also, updated links to the latest homebrew php instructions.
